### PR TITLE
fix graphcore-optimum version in qa nbook

### DIFF
--- a/notebooks/question_answering.ipynb
+++ b/notebooks/question_answering.ipynb
@@ -22,7 +22,7 @@
    },
    "outputs": [],
    "source": [
-    "%pip install optimum[graphcore]"
+    "%pip install \"optimum-graphcore>0.4, <0.5\""
    ]
   },
   {


### PR DESCRIPTION
Notebook can run successfully with the latest optimum-gc version